### PR TITLE
explicit Rcpp::as<> and uint32_t for solaris compilation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2018-11-17  Dirk Eddelbuettel  <edd@debian.org>
+
+	* src/rcppmsgpack_c_functions.cpp: Prefix as<>() calls with Rcpp as
+	Solaris cannot resolve them; also change some u_int32_t to uint32_t
+
 2018-06-29  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Date, Version): Roll minor release

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,9 @@
 	* src/rcppmsgpack_c_functions.cpp: Prefix as<>() calls with Rcpp as
 	Solaris cannot resolve them; also change some u_int32_t to uint32_t
 
+	* src/anyvector.h: Prefix all Rcpp types with Rcpp::
+	* src/rcppmsgpack_c_functions.cpp: Idem
+
 2018-06-29  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Date, Version): Roll minor release

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: RcppMsgPack
 Type: Package
 Title: 'MsgPack' C++ Header Files and Interface Functions for R
 Version: 0.2.2.2
-Date: 2018-10-27
+Date: 2018-11-17
 Author: Travers Ching and Dirk Eddelbuettel; the authors and contributors of MsgPack
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: 'MsgPack' header files are provided for use by R packages, along 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## RcppMsgPack [![Build Status](https://travis-ci.org/eddelbuettel/rcppmsgpack.svg)](https://travis-ci.org/eddelbuettel/rcppmsgpack) [![License](https://eddelbuettel.github.io/badges/GPL2+.svg)](http://www.gnu.org/licenses/gpl-2.0.html) [![CRAN](http://www.r-pkg.org/badges/version/RcppMsgPack)](https://cran.r-project.org/package=RcppMsgPack) [![Downloads](http://cranlogs.r-pkg.org/badges/RcppMsgPack?color=brightgreen)](http://www.r-pkg.org/pkg/RcppMsgPack)
+## RcppMsgPack [![Build Status](https://travis-ci.org/eddelbuettel/rcppmsgpack.svg)](https://travis-ci.org/eddelbuettel/rcppmsgpack) [![License](https://eddelbuettel.github.io/badges/GPL2+.svg)](http://www.gnu.org/licenses/gpl-2.0.html) [![CRAN](http://www.r-pkg.org/badges/version/RcppMsgPack)](https://cran.r-project.org/package=RcppMsgPack) [![Dependencies](https://tinyverse.netlify.com/badge/RcppGetconf)](https://cran.r-project.org/package=RcppGetconf) [![Downloads](http://cranlogs.r-pkg.org/badges/RcppMsgPack?color=brightgreen)](http://www.r-pkg.org/pkg/RcppMsgPack)
 
 MsgPack Headers for R and interface functions
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -6,7 +6,9 @@
 \section{Changes in version 0.2.3 (2018-07-xx)}{
   \itemize{
     \item New functions \code{msgpack_read} and \code{msgpack_write} for
-    efficient direct access to MessagePackage content from files (\ghpr{13}).
+    efficient direct access to MessagePackage content from files
+    (\ghpr{13}).
+    \item Several small internal code polishes to smooth compilation
   }
 }
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -8,7 +8,7 @@
     \item New functions \code{msgpack_read} and \code{msgpack_write} for
     efficient direct access to MessagePackage content from files
     (\ghpr{13}).
-    \item Several small internal code polishes to smooth compilation
+    \item Several internal code polishes to smooth compilation
   }
 }
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -26,7 +26,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // c_pack
-RawVector c_pack(SEXP root_obj);
+Rcpp::RawVector c_pack(SEXP root_obj);
 RcppExport SEXP _RcppMsgPack_c_pack(SEXP root_objSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
@@ -49,7 +49,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // c_timestamp_encode
-RawVector c_timestamp_encode(double seconds, uint32_t nanoseconds);
+Rcpp::RawVector c_timestamp_encode(double seconds, uint32_t nanoseconds);
 RcppExport SEXP _RcppMsgPack_c_timestamp_encode(SEXP secondsSEXP, SEXP nanosecondsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
@@ -61,7 +61,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // c_timestamp_decode
-List c_timestamp_decode(std::vector<unsigned char> v);
+Rcpp::List c_timestamp_decode(std::vector<unsigned char> v);
 RcppExport SEXP _RcppMsgPack_c_timestamp_decode(SEXP vSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -49,13 +49,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // c_timestamp_encode
-RawVector c_timestamp_encode(double seconds, u_int32_t nanoseconds);
+RawVector c_timestamp_encode(double seconds, uint32_t nanoseconds);
 RcppExport SEXP _RcppMsgPack_c_timestamp_encode(SEXP secondsSEXP, SEXP nanosecondsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< double >::type seconds(secondsSEXP);
-    Rcpp::traits::input_parameter< u_int32_t >::type nanoseconds(nanosecondsSEXP);
+    Rcpp::traits::input_parameter< uint32_t >::type nanoseconds(nanosecondsSEXP);
     rcpp_result_gen = Rcpp::wrap(c_timestamp_encode(seconds, nanoseconds));
     return rcpp_result_gen;
 END_RCPP

--- a/src/anyvector.h
+++ b/src/anyvector.h
@@ -3,7 +3,7 @@
 #include "boost/variant.hpp"
 #include <Rcpp.h>
 
-using namespace Rcpp;
+namespace Rcpp {
 
 using AnyVector = boost::variant<LogicalVector, IntegerVector, NumericVector, CharacterVector, RawVector, List>;
 
@@ -181,3 +181,5 @@ int getType(const AnyVector &vec) {
 //     }
 //     return LogicalVector::create(); // should never reach
 // }
+
+}

--- a/src/rcppmsgpack_c_functions.cpp
+++ b/src/rcppmsgpack_c_functions.cpp
@@ -10,19 +10,17 @@
 #include <cmath>
 #include <cstdint>
 
-using namespace Rcpp;
-
 const double R_INT_MAX = 2147483647;
 const double R_INT_MIN = -2147483648;
 
 SEXP c_unpack(std::vector<unsigned char> char_message);
-AnyVector unpackVector(const std::vector<msgpack::object> &obj_vector, bool const simplify);
+Rcpp::AnyVector unpackVector(const std::vector<msgpack::object> &obj_vector, bool const simplify);
 SEXP unpackVisitor(const msgpack::object &obj, bool const simplify);
-RawVector c_pack(SEXP root_obj);
+Rcpp::RawVector c_pack(SEXP root_obj);
 template <typename STREAM> void addToPack(const SEXP &obj, msgpack::packer<STREAM>& pkr);
-template <typename STREAM> void packElement(const AnyVector &vec, const LogicalVector & navec, const int j, msgpack::packer<STREAM>& pkr);
+template <typename STREAM> void packElement(const Rcpp::AnyVector &vec, const Rcpp::LogicalVector & navec, const int j, msgpack::packer<STREAM>& pkr);
 
-template <typename STREAM> void packElement(const AnyVector & vec, const LogicalVector & navec, const int j, msgpack::packer<STREAM>& pkr) {
+template <typename STREAM> void packElement(const Rcpp::AnyVector & vec, const Rcpp::LogicalVector & navec, const int j, msgpack::packer<STREAM>& pkr) {
     bool temp_bool;
     double temp_double;
     int temp_int;
@@ -33,42 +31,42 @@ template <typename STREAM> void packElement(const AnyVector & vec, const Logical
         if(navec[j]) {
             pkr.pack_nil();
         } else {
-            temp_bool = boost::get<LogicalVector>(vec)[j];
+            temp_bool = boost::get<Rcpp::LogicalVector>(vec)[j];
             pkr.pack(temp_bool);
         }
         break;
     case INTSXP:
-        temp_int = boost::get<IntegerVector>(vec)[j];
+        temp_int = boost::get<Rcpp::IntegerVector>(vec)[j];
         pkr.pack(temp_int);
         // pkr.pack( as< std::vector<int> >(boost::get<IntegerVector>(vec))[j] );
         break;
     case REALSXP:
-        temp_double = boost::get<NumericVector>(vec)[j];
+        temp_double = boost::get<Rcpp::NumericVector>(vec)[j];
         pkr.pack(temp_double);
         break;
     case STRSXP:
         if(navec[j]) {
             pkr.pack_nil();
         } else {
-            temp_string = boost::get<CharacterVector>(vec)[j];
+            temp_string = boost::get<Rcpp::CharacterVector>(vec)[j];
             pkr.pack(temp_string);
         }
         break;
     case VECSXP:
-        addToPack(boost::get<List>(vec)[j], pkr);
+        addToPack(boost::get<Rcpp::List>(vec)[j], pkr);
     }
 }
 
 template <typename STREAM> void addToPack(const SEXP &obj, msgpack::packer<STREAM>& pkr) {
     if(Rf_isVectorList(obj)) {
-        List temp_list = List(obj);
+        Rcpp::List temp_list = Rcpp::List(obj);
         // Map
         if(temp_list.hasAttribute("class") && (Rcpp::as< std::vector<std::string> >(temp_list.attr("class")))[0] == "map") {
             // std::cout << "map:" << std::endl;
-            AnyVector key = sexpToAnyVector(temp_list[0]);
-            AnyVector value = sexpToAnyVector(temp_list[1]);
-            LogicalVector nakey = is_na(key);
-            LogicalVector navalue = is_na(value);
+            Rcpp::AnyVector key = sexpToAnyVector(temp_list[0]);
+            Rcpp::AnyVector value = sexpToAnyVector(temp_list[1]);
+            Rcpp::LogicalVector nakey = is_na(key);
+            Rcpp::LogicalVector navalue = is_na(value);
             int len = size(key);
             pkr.pack_map(len);
             for(int j=0; j<len; j++) {
@@ -77,8 +75,8 @@ template <typename STREAM> void addToPack(const SEXP &obj, msgpack::packer<STREA
             }
             // Also Map
         } else if(temp_list.hasAttribute("names")) {
-            CharacterVector keys = temp_list.names();
-            LogicalVector nakeys = is_na(keys);
+            Rcpp::CharacterVector keys = temp_list.names();
+            Rcpp::LogicalVector nakeys = is_na(keys);
             pkr.pack_map(temp_list.size());
             for(int j=0; j<temp_list.size(); j++) {
                 if(nakeys[j]) {
@@ -90,14 +88,14 @@ template <typename STREAM> void addToPack(const SEXP &obj, msgpack::packer<STREA
             }
             // Array
         } else {
-            List temp_list = List(obj);
+            Rcpp::List temp_list = Rcpp::List(obj);
             pkr.pack_array(temp_list.size());
             for(int j=0; j<temp_list.size(); j++) {
                 addToPack(temp_list[j], pkr);
             }
         }
     } else if(TYPEOF(obj) == RAWSXP) {
-        RawVector rv = RawVector(obj);
+        Rcpp::RawVector rv = Rcpp::RawVector(obj);
         // EXT
         if(rv.hasAttribute("EXT")) {
             std::vector<unsigned char> rvvu = Rcpp::as< std::vector<unsigned char> >(obj);
@@ -114,13 +112,13 @@ template <typename STREAM> void addToPack(const SEXP &obj, msgpack::packer<STREA
     } else if(TYPEOF(obj) == NILSXP) {
         pkr.pack_nil();
     } else {
-        AnyVector vec = sexpToAnyVector(obj);
+        Rcpp::AnyVector vec = Rcpp::sexpToAnyVector(obj);
         int vec_size = size(vec);
-        LogicalVector navec = is_na(vec);
+        Rcpp::LogicalVector navec = is_na(vec);
         // Map again
         if(hasAttribute(vec, "names")) {
-            CharacterVector key = attr(vec, "names");
-            LogicalVector nakey = is_na(key);
+            Rcpp::CharacterVector key = attr(vec, "names");
+            Rcpp::LogicalVector nakey = is_na(key);
             pkr.pack_map(vec_size);
             for(int j=0; j < vec_size; j++) {
                 if(nakey[j]) {
@@ -143,31 +141,31 @@ template <typename STREAM> void addToPack(const SEXP &obj, msgpack::packer<STREA
 }
 
 // [[Rcpp::export]]
-RawVector c_pack(SEXP root_obj) {
+Rcpp::RawVector c_pack(SEXP root_obj) {
     //std::stringstream buffer;
     // msgpack::packer<std::stringstream> pk(&buffer);
     msgpack::sbuffer sbuf;
     msgpack::packer<msgpack::sbuffer> pk(&sbuf);
     if(Rf_isVectorList(root_obj)) {
-        List root_list = List(root_obj);
+        Rcpp::List root_list = Rcpp::List(root_obj);
         if(root_list.hasAttribute("class") && (Rcpp::as< std::vector<std::string> >(root_list.attr("class")))[0] == "msgpack_set") {
             for(int i=0; i<root_list.size(); i++) {
                 addToPack(root_list[i], pk);
             }
             // std::string bufstr = buffer.str();
             //RawVector bufraw(bufstr.begin(), bufstr.end());
-            RawVector bufraw(sbuf.data(), sbuf.data()+sbuf.size());
+            Rcpp::RawVector bufraw(sbuf.data(), sbuf.data()+sbuf.size());
             return bufraw;
         }
     }
     addToPack(root_obj, pk);
     // std::string bufstr = buffer.str();
     // RawVector bufraw(bufstr.begin(), bufstr.end());
-    RawVector bufraw(sbuf.data(), sbuf.data()+sbuf.size());
+    Rcpp::RawVector bufraw(sbuf.data(), sbuf.data()+sbuf.size());
     return bufraw;
 }
 
-AnyVector unpackVector(const std::vector<msgpack::object> &obj_vector, bool const simplify) {
+Rcpp::AnyVector unpackVector(const std::vector<msgpack::object> &obj_vector, bool const simplify) {
     
     // reusable objects for converting from msgpack::object
     bool temp_bool;
@@ -221,21 +219,21 @@ AnyVector unpackVector(const std::vector<msgpack::object> &obj_vector, bool cons
         }
         if(sum_types == 1) {
             if(numeric_type && !null_type) {
-                NumericVector v = NumericVector(obj_vector.size());
+                Rcpp::NumericVector v = Rcpp::NumericVector(obj_vector.size());
                 for (unsigned int j=0; j<obj_vector.size(); j++) {
                     obj_vector[j].convert(temp_double);
                     v[j] = temp_double;
                 }
                 return v;
             } else if(integer_type && !null_type) {
-                IntegerVector v = IntegerVector(obj_vector.size());
+                Rcpp::IntegerVector v = Rcpp::IntegerVector(obj_vector.size());
                 for (unsigned int j=0; j<obj_vector.size(); j++) {
                     obj_vector[j].convert(temp_int);
                     v[j] = temp_int;
                 }
                 return v;
             } else if(logical_type) {
-                LogicalVector v = LogicalVector(obj_vector.size());
+                Rcpp::LogicalVector v = Rcpp::LogicalVector(obj_vector.size());
                 for (unsigned int j=0; j<obj_vector.size(); j++) {
                     if(obj_vector[j].type == msgpack::type::NIL) {
                         v[j] = NA_LOGICAL;
@@ -246,7 +244,7 @@ AnyVector unpackVector(const std::vector<msgpack::object> &obj_vector, bool cons
                 }
                 return v;
             } else if(character_type) {
-                CharacterVector v = CharacterVector(obj_vector.size());
+                Rcpp::CharacterVector v = Rcpp::CharacterVector(obj_vector.size());
                 for (unsigned int j=0; j<obj_vector.size(); j++) {
                     if(obj_vector[j].type == msgpack::type::NIL) {
                         v[j] = NA_STRING;
@@ -261,7 +259,7 @@ AnyVector unpackVector(const std::vector<msgpack::object> &obj_vector, bool cons
     }
     // list type
     // vector size 0 also returns empty list
-    List L = List(obj_vector.size());
+    Rcpp::List L = Rcpp::List(obj_vector.size());
     for (unsigned int j=0; j<obj_vector.size(); j++) {
         L[j] = unpackVisitor(obj_vector[j], simplify);
     }
@@ -285,27 +283,27 @@ SEXP unpackVisitor(const msgpack::object &obj, bool const simplify) {
             value_vector[i] = p->val.as<msgpack::object>();
             i++;
         }
-        AnyVector keys = unpackVector(key_vector, simplify);
-        AnyVector values = unpackVector(value_vector, simplify);
+        Rcpp::AnyVector keys = unpackVector(key_vector, simplify);
+        Rcpp::AnyVector values = unpackVector(value_vector, simplify);
         if(simplify && getType(keys) == STRSXP) {
-            setAttr(values, "names", boost::get<CharacterVector>(keys));
+            setAttr(values, "names", boost::get<Rcpp::CharacterVector>(keys));
             // map[1].attr("names") = CharacterVector(map[0]);
             return anyVectorToSexp(values);
         } else {
-            List map = List(2);
+            Rcpp::List map = Rcpp::List(2);
             map[0] = anyVectorToSexp(keys);
             map[1] = anyVectorToSexp(values);
-            map.attr("class") = CharacterVector::create("map", "data.frame");
-            map.attr("row.names") = seq_len(msize);
-            map.names() = CharacterVector::create("key", "value");
+            map.attr("class") = Rcpp::CharacterVector::create("map", "data.frame");
+            map.attr("row.names") = Rcpp::seq_len(msize);
+            map.names() = Rcpp::CharacterVector::create("key", "value");
             return map;
         }
     } else if(obj.type == msgpack::type::EXT) {
         int8_t vtype = obj.via.ext.type();
         uint32_t vsize = obj.via.ext.size;
         const char* vdata = obj.via.ext.data();
-        RawVector rv = RawVector(vdata, vdata + vsize);
-        rv.attr("EXT") = IntegerVector::create(vtype);
+        Rcpp::RawVector rv = Rcpp::RawVector(vdata, vdata + vsize);
+        rv.attr("EXT") = Rcpp::IntegerVector::create(vtype);
         return rv;
     } else {
         
@@ -323,34 +321,34 @@ SEXP unpackVisitor(const msgpack::object &obj, bool const simplify) {
         case msgpack::type::BOOLEAN:
             // std::cout << "boolean" << std::endl;
             obj.convert(temp_bool);
-            return wrap(temp_bool);
+            return Rcpp::wrap(temp_bool);
         case msgpack::type::POSITIVE_INTEGER:
         case msgpack::type::NEGATIVE_INTEGER:
             // std::cout << "integer" << std::endl;
             obj.convert(temp_double);
             if(temp_double <= R_INT_MAX && temp_double >= R_INT_MIN) {
                 obj.convert(temp_int);
-                return wrap(temp_int);
+                return Rcpp::wrap(temp_int);
             } else {
-                return wrap(temp_double);
+                return Rcpp::wrap(temp_double);
             }
         case msgpack::type::FLOAT32:
         case msgpack::type::FLOAT64:
             // std::cout << "float" << std::endl;
             obj.convert(temp_double);
-            return wrap(temp_double);
+            return Rcpp::wrap(temp_double);
         case msgpack::type::STR:
             // std::cout << "string" << std::endl;
             obj.convert(temp_string);
-            return wrap(temp_string);
+            return Rcpp::wrap(temp_string);
         case msgpack::type::BIN:
             obj.convert(temp_unsigned_char);
-            return RawVector(temp_unsigned_char.begin(), temp_unsigned_char.end());
+            return Rcpp::RawVector(temp_unsigned_char.begin(), temp_unsigned_char.end());
         default:
             break;
         }
     }
-    return LogicalVector::create(); //should never reach
+    return Rcpp::LogicalVector::create(); //should never reach
 }
 
 
@@ -373,7 +371,7 @@ SEXP c_unpack(std::vector<unsigned char> char_message, bool simplify) {
         L.push_back(unpackVisitor(obj, simplify));
     }
     if(L.size() != 1) {
-        List LL = List(L.size());
+        Rcpp::List LL = Rcpp::List(L.size());
         for(uint i=0; i<L.size(); i++) {
             LL[i] = L[i];
         }
@@ -392,15 +390,15 @@ SEXP c_unpack(std::vector<unsigned char> char_message, bool simplify) {
 // 0xc7 | 12 | -1 | nanoseconds in 32-bit unsigned int | seconds in 64-bit signed int
 //Bit operations: https://stackoverflow.com/questions/47981/how-do-you-set-clear-and-toggle-a-single-bit
 // [[Rcpp::export]]
-RawVector c_timestamp_encode(double seconds, uint32_t nanoseconds) {
+Rcpp::RawVector c_timestamp_encode(double seconds, uint32_t nanoseconds) {
     int64_t secint = round(seconds);
-    RawVector rv;
+    Rcpp::RawVector rv;
     if ((nanoseconds == 0) & (seconds <= 4294967295) & (seconds >= 0)) { //2^32-1
         std::vector<unsigned char> msg(4);
         for(int i=0; i<32; i++) {
             if((secint >> i) & 1) msg[(31-i)/8] |= 1 << (i % 8);
         }
-        rv = RawVector(msg.begin(), msg.end());
+        rv = Rcpp::RawVector(msg.begin(), msg.end());
     } else if ((seconds <= 17179869183) & (seconds >= 0)) { //2^34-1
         std::vector<unsigned char> msg(8);
         for(int i=0; i<34; i++) {
@@ -409,7 +407,7 @@ RawVector c_timestamp_encode(double seconds, uint32_t nanoseconds) {
         for(int i=0; i<30; i++) {
             if((nanoseconds >> i) & 1) msg[(29-i)/8] |= 1 << ((i+2) % 8);
         }
-        rv = RawVector(msg.begin(), msg.end());
+        rv = Rcpp::RawVector(msg.begin(), msg.end());
     } else {
         std::vector<unsigned char> msg(12);
         for(int i=0; i<64; i++) {
@@ -418,14 +416,14 @@ RawVector c_timestamp_encode(double seconds, uint32_t nanoseconds) {
         for(int i=0; i<32; i++) {
             if((nanoseconds >> i) & 1) msg[(31-i)/8] |= 1 << (i % 8);
         }
-        rv = RawVector(msg.begin(), msg.end());
+        rv = Rcpp::RawVector(msg.begin(), msg.end());
     }
-    rv.attr("EXT") = IntegerVector::create(-1);
+    rv.attr("EXT") = Rcpp::IntegerVector::create(-1);
     return rv;
 }
 
 // [[Rcpp::export]]
-List c_timestamp_decode(std::vector<unsigned char> v) {
+Rcpp::List c_timestamp_decode(std::vector<unsigned char> v) {
     int64_t seconds;
     int nanoseconds;
     if(v.size() == 4) {
@@ -449,9 +447,9 @@ List c_timestamp_decode(std::vector<unsigned char> v) {
             (static_cast<int64_t>(v[10]) << 8) |
             static_cast<int64_t>(v[11]);
     }
-    List l = List(2);
+    Rcpp::List l = Rcpp::List(2);
     l[0] = static_cast<double>(seconds);
     l[1] = nanoseconds;
-    l.attr("names") = CharacterVector::create("seconds", "nanoseconds");
+    l.attr("names") = Rcpp::CharacterVector::create("seconds", "nanoseconds");
     return l;
 }


### PR DESCRIPTION
Hi @traversc 
CRAN offers these checks about how the package(s) are doing and I have been slowly working down my liist of `ERROR` outcomes. The [report for our package](https://cloud.r-project.org/web/checks/check_results_RcppMsgPack.html) shows a [build-failure on Solaris](https://www.r-project.org/nosvn/R.check/r-patched-solaris-x86/RcppMsgPack-00check.html).

Because we generally did not have (easy) access to Solaris I mostly ignored these over the years. But [RHub](https://builder.r-hub.io/) can build on Solaris, so I gave this a shot.  The PR is actually pretty small.  We need to disambiguate `as<>()` with a `Rcpp::` prefix, and for some reason we (again?) have the dreaded `u_int32_t` when it should be `uint32_t` per the `csdtint` header.  

Please take a look if you get a minute, this is not changing any internals or behavior and should be simple.