### PR TITLE
Distinguish between int and numeric columns (closes #18)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 2025-10-25  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Date, Version): Roll micro release
+
+	* src/rcppmsgpack_c_functions.cpp (unpackVector): Treat integer and
+	numeric as distinct types for one-row data.frames containing them
+
 	* cleanup: Add simple helper
 
 2025-01-19  Dirk Eddelbuettel  <edd@debian.org>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: RcppMsgPack
 Type: Package
 Title: 'MsgPack' C++ Header Files and Interface Functions for R
-Version: 0.2.4
-Date: 2025-01-19
+Version: 0.2.4.1
+Date: 2025-10-25
 Authors@R: c(person("Dirk", "Eddelbuettel", role = c("aut", "cre"), email = "edd@debian.org",
                     comment = c(ORCID = "0000-0001-6419-907X")),
              person("Travers", "Ching", email = "traversc@gmail.com", role = "aut"),

--- a/src/rcppmsgpack_c_functions.cpp
+++ b/src/rcppmsgpack_c_functions.cpp
@@ -213,7 +213,7 @@ Rcpp::AnyVector unpackVector(const std::vector<msgpack::object> &obj_vector, boo
                 list_type = true;
             break;
             }
-            sum_types = (numeric_type || integer_type) + logical_type + character_type + list_type;
+            sum_types = numeric_type + integer_type + logical_type + character_type + list_type;
             if(list_type) break;
             if((numeric_type || integer_type) && null_type) break;
             if(sum_types > 1) break;


### PR DESCRIPTION
The report in #18 shows that a one-row data.frame with an integer and a numeric column is not treated correctly.  This can be traced to the C++ code with integer _or_ numeric are treated as just numeric.  If we keep this (optimisation ?) seperate, the issue originally report in #18 goes away,

Tests still pass. I also tested against our one reverse dependency and my own reverse suggests (though I cannot recall if it has tests for RcppMsgPack in there) and everything still passes.

@traversc Can you take a look at the one-line change, and its context, and ponder if making this change may have any unintended adverse effects?